### PR TITLE
Use an actual UUID for the `uuid` field

### DIFF
--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -4,7 +4,7 @@ module ApplicationCable
     identified_by :uuid
 
     def connect
-      self.uuid = SecureRandom.hex
+      self.uuid = SecureRandom.uuid
     end
   end
 end


### PR DESCRIPTION
It is unclear whether `SecureRandom.hex` generates the correct amount of randomness, while [`SecureRandom.uuid`](http://ruby-doc.org/stdlib-2.2.3/libdoc/securerandom/rdoc/SecureRandom.html#method-c-uuid) is self-evidently correct.
