### PR TITLE
Checkmate

### DIFF
--- a/app/assets/javascripts/board.coffee
+++ b/app/assets/javascripts/board.coffee
@@ -23,6 +23,8 @@ $ ->
       if (move == null)
         # illegal move
         return "snapback"
+      else if (App.chess.game_over())
+        alert("checkmate!")
       else
         App.game.perform("make_move", move)
         App.board.position(App.chess.fen(), false)

--- a/app/assets/javascripts/cable.coffee
+++ b/app/assets/javascripts/cable.coffee
@@ -1,8 +1,6 @@
 # Action Cable provides the framework to deal with WebSockets in Rails. 
 # You can generate new channels where WebSocket features live using the rails generate channel command.
-#
-# Turn on the cable connection by removing the comments after the require statements (and ensure it's also on in config/routes.rb).
-#
+
 #= require action_cable
 #= require_self
 #= require_tree ./channels


### PR DESCRIPTION
For a checkmate, moves for both sides will freeze up but there is no message to either user that a checkmate has occurred.  This is just a simple alert to notify of checkmate.  A better solution would probably have it in the messages at the bottom, which I can add later, in the meantime this is a temp fix :)
